### PR TITLE
Better support for OpenCV & RXTX

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ OpenJDK JRI is preinstalled in the default image, so you only need to install ev
 ```
 If you want to use RXTX or OpenCV, you can install them this way:
 ```bash
-./gradlew updateAPT installNativeLibraries
+./gradlew updateAPT installOpenCV installRXTX
 ```
 
 ### Other platforms
@@ -53,7 +53,7 @@ On these platforms OpenJDK JRE needs to be installed from Debian repositories to
 ```
 If you want to use RXTX or OpenCV, you can again install them this way:
 ```bash
-./gradlew updateAPT installNativeLibraries
+./gradlew updateAPT installOpenCV installRXTX
 ```
 
 ## Configuration
@@ -103,7 +103,8 @@ You can use the Java IDE to launch the tasks or you can execute them from the te
 - `helpInstall` - Print the installer help.
 - `getInstaller` - Download the installer to the brick.
 - `installJava` - Install Java on the brick.
-- `installNativeLibraries` - Install native libraries on the brick.
+- `installOpenCV` - Install OpenCV libraries on the brick.
+- `installRXTX` - Install RXTX library on the brick.
 - `installJavaLibraries` - Install EV3Dev-lang-java libraries on the brick.
 - `javaVersion` - Print Java version which is present on the brick.
 - `updateAPT` - Update APT package cache.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ You can change the project configuration in `config.gradle`.
 - `brickHost` - IP address of your brick.
 - `brickUser` - Username on your brick.
 - `brickPassword` - Password for the `brickUser`.
+- `opencv` - Whether to include OpenCV libraries.
+- `rxtx` - Whether to include RXTX library.
+- `userClasspath` - List of additional URLs for runtime Java classpath.
 - `jvmPrefix` - Commands which are prepended before the Java itself. **Keep at least one space character after each command.**
   - `time ` - Can be used to measure the time for which the program runs.
   - `brickrun -- ` - Should be used when running the program on a brick with a display.
@@ -75,6 +78,7 @@ You can change the project configuration in `config.gradle`.
   - `-XX:TieredStopAtLevel=1 ` - Do not perform many optimizations. This can be used to speed up startup time.
   - `-Djava.security.egd=file:/dev/./urandom ` - This can be used to speed up random number generation.
 - `slimJar` - Whether to generate a small JAR with external dependencies, or rather to generate a fat jar with embedded dependencies.
+- `useEmbeddedPaths` - Whehter to use classpath and mainclass embedded in JAR or if they should be supplied on the command line.
 
 ## Gradle Tasks
 

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ jar {
         attributes("Implementation-Title": project.name,
                    "Implementation-Version": version,
                    "Main-Class": project.mainClass,
-                   "Class-Path": project.getJarClassPath() )
+                   "Class-Path": project.getClassPath(true) )
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,12 +37,19 @@ task wrapper(type: Wrapper) {
 
 repositories {
     maven { url "https://jitpack.io" }
+    maven { url "http://repo.opennms.org/maven2/" }
     mavenCentral()
 }
 
 dependencies {
-    compile("org.slf4j:slf4j-simple:1.7.25")
-    compile("com.github.ev3dev-lang-java:ev3dev-lang-java:2.5.3")
+    compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
+    compile group: 'com.github.ev3dev-lang-java', name: 'ev3dev-lang-java', version: '2.5.3'
+
+    if (project.ext.has("opencv") && project.ext.opencv)
+        compileOnly group: 'org.openpnp', name: 'opencv', version: '2.4.9-8'
+
+    if (project.ext.has("rxtx")   && project.ext.rxtx)
+        compileOnly group: 'org.rxtx', name: 'rxtx', version: '2.2pre2', ext: 'pom'
 }
 
 compileJava.options.encoding = 'UTF-8'
@@ -58,7 +65,8 @@ jar {
     manifest {
         attributes("Implementation-Title": project.name,
                    "Implementation-Version": version,
-                   "Main-Class": project.mainClass)
+                   "Main-Class": project.mainClass,
+                   "Class-Path": project.getJarClassPath() )
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,19 +37,12 @@ task wrapper(type: Wrapper) {
 
 repositories {
     maven { url "https://jitpack.io" }
-    maven { url "http://repo.opennms.org/maven2/" }
     mavenCentral()
 }
 
 dependencies {
     compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
     compile group: 'com.github.ev3dev-lang-java', name: 'ev3dev-lang-java', version: '2.5.3'
-
-    if (project.ext.has("opencv") && project.ext.opencv)
-        compileOnly group: 'org.openpnp', name: 'opencv', version: '2.4.9-8'
-
-    if (project.ext.has("rxtx")   && project.ext.rxtx)
-        compileOnly group: 'org.rxtx', name: 'rxtx', version: '2.2pre2', ext: 'pom'
 }
 
 compileJava.options.encoding = 'UTF-8'

--- a/config.gradle
+++ b/config.gradle
@@ -38,4 +38,6 @@ project.ext {
 
     // Slim | FatJar
     slimJar = true
+    // Use paths from JAR directly from project
+    useEmbeddedPaths = true
 }

--- a/config.gradle
+++ b/config.gradle
@@ -9,6 +9,13 @@ project.ext {
     brickUser = "robot"
     brickPassword = "maker"
 
+    // some common libraries
+    opencv = true
+    rxtx = true
+    // additional classpath entries
+    // userClasspath = [ "file:///path/to/a.jar", "file:///path/to/b.jar" ]
+    userClasspath = []
+
     // Commands preceding Java
     jvmPrefix += "time "
     //jvmPrefix += "brickrun -- "

--- a/config.gradle
+++ b/config.gradle
@@ -9,12 +9,10 @@ project.ext {
     brickUser = "robot"
     brickPassword = "maker"
 
-    // some common libraries
+    // Library section //
     opencv = true
     rxtx = true
-    // additional classpath entries
-    // userClasspath = [ "file:///path/to/a.jar", "file:///path/to/b.jar" ]
-    userClasspath = []
+    // userClasspath += "file:///path/to/a.jar"
 
     // Commands preceding Java
     jvmPrefix += "time "
@@ -36,8 +34,7 @@ project.ext {
     //jvmFlags += "-Djava.security.egd=file:/dev/./urandom "
     //jvmFlags += "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=7091 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false "
 
-    // Slim | FatJar
+    // JAR behaviour //
     slimJar = true
-    // Use paths from JAR directly from project
     useEmbeddedPaths = true
 }

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -24,7 +24,11 @@ def getJavaCommand(wrapper) {
     if (project.appCDS) {
         cdsLine = "-XX:+UnlockDiagnosticVMOptions -XX:+UseAppCDS -XX:SharedArchiveFile=${project.appcdsJsaPath()}"
     }
-    specArgs = "-jar ${project.userJarPath()}"
+    if (project.useEmbeddedPaths) {
+        specArgs = "-jar ${project.userJarPath()}"
+    } else {
+        specArgs = "-cp \"${project.getClassPath(false)}\" ${project.mainClass}"
+    }
 
     def prefixPart = jvmPrefix
     if (wrapper) {
@@ -121,11 +125,11 @@ if (project.appCDS) {
             ssh.run {
                 session(remotes.ev3dev) {
                     project.sshPrint(delegate, "java \
+                                            -cp \"${project.getClassPath(false)}\" \
                                             -XX:+UnlockDiagnosticVMOptions -XX:+UseAppCDS \
                                             -Xshare:dump \
                                             -XX:SharedClassListFile=${project.appcdsLstPath()} \
-                                            -XX:SharedArchiveFile=${project.appcdsJsaPath()} \
-                                            -jar ${ project.userJarPath() }")
+                                            -XX:SharedArchiveFile=${project.appcdsJsaPath()}")
                 }
             }
         }

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -16,18 +16,6 @@ def baseGroup = "ELJ-Deployment"
 // TASK HELPERS //
 //////////////////
 
-/////////////////////////////////
-// Get classpath for a Slim JAR
-project.ext.getSlimClassPath = {
-    def dependenciesPath = "${ project.userJarPath() }"
-
-    configurations.runtime.each {
-        dependenciesPath += ":${ project.externalJarsPath }/${ it.name }"
-    }
-
-    return dependenciesPath
-}
-
 ////////////////////////////////////////
 // Get command line for java execution
 def getJavaCommand(wrapper) {
@@ -36,11 +24,7 @@ def getJavaCommand(wrapper) {
     if (project.appCDS) {
         cdsLine = "-XX:+UnlockDiagnosticVMOptions -XX:+UseAppCDS -XX:SharedArchiveFile=${project.appcdsJsaPath()}"
     }
-    if (project.slimJar) {
-        specArgs = "-cp \"${project.getSlimClassPath()}\" ${project.mainClass}"
-    } else {
-        specArgs = "-jar ${project.userJarPath()}"
-    }
+    specArgs = "-jar ${project.userJarPath()}"
 
     def prefixPart = jvmPrefix
     if (wrapper) {
@@ -137,11 +121,11 @@ if (project.appCDS) {
             ssh.run {
                 session(remotes.ev3dev) {
                     project.sshPrint(delegate, "java \
-                                            -cp \"${project.getSlimClassPath()}\" \
                                             -XX:+UnlockDiagnosticVMOptions -XX:+UseAppCDS \
                                             -Xshare:dump \
                                             -XX:SharedClassListFile=${project.appcdsLstPath()} \
-                                            -XX:SharedArchiveFile=${project.appcdsJsaPath()}")
+                                            -XX:SharedArchiveFile=${project.appcdsJsaPath()} \
+                                            -jar ${ project.userJarPath() }")
                 }
             }
         }

--- a/gradle/installer.gradle
+++ b/gradle/installer.gradle
@@ -36,9 +36,13 @@ project.createSudoCommandTask(installerGroup, "installJava",
     "/home/robot/java/installer.sh java",
     "Install Java on the brick.")
 
-project.createSudoCommandTask(installerGroup, "installNativeLibraries",
-    "/home/robot/java/installer.sh nativeLibs",
-    "Install native libraries on the brick.")
+project.createSudoCommandTask(installerGroup, "installOpenCV",
+    "/home/robot/java/installer.sh opencv",
+    "Install OpenCV libraries on the brick.")
+
+project.createSudoCommandTask(installerGroup, "installRXTX",
+    "/home/robot/java/installer.sh rxtx",
+    "Install RXTX library on the brick.")
 
 project.createSudoCommandTask(installerGroup, "installJavaLibraries",
     "/home/robot/java/installer.sh javaLibs",

--- a/gradle/utility.gradle
+++ b/gradle/utility.gradle
@@ -61,8 +61,23 @@ project.ext.createSudoCommandTask = { grpName, name, command, desc = "" ->
     project.createCommandTask(grpName, name, "echo -e \"${project.brickPassword}\" | sudo -S $command", desc)
 }
 
+//////////////////////////////////////////
+// Modify classpath URL for given target
+// - forJar - true  -> set up for MANIFEST.MF
+//          - false -> set up for -cp option
+// - url - class path entry to modify
+project.ext.filterClassURL = { forJar, url ->
+    if (forJar) {
+        return url
+    } else {
+        return url.replaceAll("^file://", "")
+    }
+}
+
 /////////////////////////////
 // Determine JAR class-path
+// - forJar - true  -> set up for MANIFEST.MF
+//          - false -> set up for -cp option
 project.ext.getClassPath = { forJar ->
     def jarList = []
 
@@ -77,15 +92,15 @@ project.ext.getClassPath = { forJar ->
     }
 
     if (project.ext.has("opencv") && project.ext.opencv) {
-        jarList += "file://${project.opencvJar}"
+        jarList += filterClassURL(forJar, "file://${project.opencvJar}")
     }
 
     if (project.ext.has("rxtx") && project.ext.rxtx) {
-        jarList += "file://${project.rxtxJar}"
+        jarList += filterClassURL(forJar, "file://${project.rxtxJar}")
     }
 
     if (project.ext.has("userClasspath")) {
-        jarList += project.ext.userClasspath
+        jarList += project.ext.userClasspath.collect { filterClassURL(forJar, it) }
     }
 
     if (forJar) {

--- a/gradle/utility.gradle
+++ b/gradle/utility.gradle
@@ -17,6 +17,8 @@ project.ext.splashPath = "/home/robot/java/splash.txt"
 project.ext.appcdsPath = "/home/robot/java/appcds"
 project.ext.appcdsLstPath = { return "/home/robot/java/appcds/all.lst" }
 project.ext.appcdsJsaPath = { return "/home/robot/java/appcds/${rootProject.name}-${version}.jsa" }
+project.ext.opencvJar = "/usr/share/java/opencv.jar"
+project.ext.rxtxJar = "/usr/share/java/RXTXcomm.jar"
 project.ext.userJarPath = {
     def suffix = project.slimJar ? "" : "-all";
     return "${project.userJarsPath}/${rootProject.name}-${version}${suffix}.jar";
@@ -46,6 +48,7 @@ project.ext.createCommandTask = { grpName, name, command, desc = "" ->
         }
     }
 }
+
 //////////////////////////////////
 // Create a Basic task with Sudo
 // normal arguments:
@@ -55,4 +58,30 @@ project.ext.createCommandTask = { grpName, name, command, desc = "" ->
 //  - desc:    optional task description
 project.ext.createSudoCommandTask = { grpName, name, command, desc = "" ->
     project.createCommandTask(grpName, name, "echo -e \"${project.brickPassword}\" | sudo -S $command", desc)
+}
+
+/////////////////////////////
+// Determine JAR class-path
+project.ext.getJarClassPath = {
+    def jarList = []
+
+    if (project.slimJar) {
+        configurations.runtime.each {
+            jarList += "file://${ project.externalJarsPath }/${ it.name }"
+        }
+    }
+
+    if (project.ext.has("opencv") && project.ext.opencv) {
+        jarList += "file://${project.opencvJar}"
+    }
+
+    if (project.ext.has("rxtx") && project.ext.rxtx) {
+        jarList += "file://${project.rxtxJar}"
+    }
+
+    if (project.ext.has("userClasspath")) {
+        jarList += project.ext.userClasspath
+    }
+
+    return jarList.join(" ")
 }

--- a/gradle/utility.gradle
+++ b/gradle/utility.gradle
@@ -1,5 +1,6 @@
 project.ext.jvmPrefix = ""
 project.ext.jvmFlags = ""
+project.ext.userClasspath = []
 
 // Whether to enable experimental AppCDS caching
 project.ext.appCDS = false

--- a/gradle/utility.gradle
+++ b/gradle/utility.gradle
@@ -62,12 +62,16 @@ project.ext.createSudoCommandTask = { grpName, name, command, desc = "" ->
 
 /////////////////////////////
 // Determine JAR class-path
-project.ext.getJarClassPath = {
+project.ext.getClassPath = { forJar ->
     def jarList = []
 
     if (project.slimJar) {
         configurations.runtime.each {
-            jarList += "file://${ project.externalJarsPath }/${ it.name }"
+            if (forJar) {
+                jarList += "file://${ project.externalJarsPath }/${ it.name }"
+            } else {
+                jarList += "${ project.externalJarsPath }/${ it.name }"
+            }
         }
     }
 
@@ -83,5 +87,10 @@ project.ext.getJarClassPath = {
         jarList += project.ext.userClasspath
     }
 
-    return jarList.join(" ")
+    if (forJar) {
+        return jarList.join(" ")
+    } else {
+        jarList += userJarPath()
+        return jarList.join(":")
+    }
 }


### PR DESCRIPTION
This is a counterpart of https://github.com/ev3dev-lang-java/installer/pull/41 - split OpenCV and RXTX installers.

Features:
* It adds boolean flags `opencv=true/false` and `rxtx=true/false` to `config.gradle`. When used, they automatically add OpenCV and RXTX to `compileOnly()` and to the jar classpath.
* It adds an option for custom class paths.
* It adds automatic generation of classpath for jar manifest.
* It allows switching between using classpath from Gradle by using `-cp prg.jar:a.jar class` and using classpath from JAR manifest via `-jar prg.jar`

~~I haven't updated README yet.~~