### PR TITLE
Add code to copy JAR dependencies to a directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,3 +57,7 @@ jar {
     }
 }
 
+task copyDependencies(type: Copy) {
+    from configurations.compile
+    into "${project.buildDir}/deps"
+}


### PR DESCRIPTION
 - task name 'copyDependencies'
 - it puts JARs of dependencies in &lt;build&gt;/deps directory (change from the proposal)
 - proposed by @mingan666 in https://github.com/ev3dev-lang-java/ev3dev-lang-java/issues/643