### PR TITLE
Update gradle-plugin to version 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,92 +36,18 @@ The project includes some tasks to reduce the time to deploy on your robot.
 To start, change the `brickHost`, `brickUser` and `brickPassword` properties in `config.gradle`. Then, continue to the brick setup.
 
 ## Brick setup
-### EV3
-OpenJDK JRI is preinstalled in the default image, so you only need to install ev3dev-lang-java libraries:
-```bash
-./gradlew getInstaller installJavaLibraries
-```
-If you want to use RXTX or OpenCV, you can install them this way:
-```bash
-./gradlew updateAPT installOpenCV installRXTX
-```
 
-### Other platforms
-On these platforms OpenJDK JRE needs to be installed from Debian repositories too:
-```bash
-./gradlew getInstaller updateAPT installJava installJavaLibraries
-```
-If you want to use RXTX or OpenCV, you can again install them this way:
-```bash
-./gradlew updateAPT installOpenCV installRXTX
-```
+Please see https://github.com/ev3dev-lang-java/gradle-plugin#whats-next .
 
 ## Configuration
 
 You can change the project configuration in `config.gradle`.
-- `mainClass` - Main class of your program.
-- `brickHost` - IP address of your brick.
-- `brickUser` - Username on your brick.
-- `brickPassword` - Password for the `brickUser`.
-- `opencv` - Whether to include OpenCV libraries.
-- `rxtx` - Whether to include RXTX library.
-- `userClasspath` - List of additional URLs for runtime Java classpath.
-- `useTime` - Can be used to measure the time for which the program runs.
-- `useBrickman` - Should be used when running the program on a brick with a display.
-- `useSudo` - If true, the program is launched under root.
-- `jvmFlags` - Flags for Java Virtual Machine.
-  - `-Xlog:class+load=info,class+unload=info ` - Display the debugging info for class loading.
-  - `-Xshare:on ` - Enable Class Data Sharing (recommended).
-  - `-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=7091 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false ` - Enable JMX agent.
-  - `-noverify ` - Do not verify class bytecode. This can be used to speed up startup time, but it is also a potential big security risk.
-  - `-XX:TieredStopAtLevel=1 ` - Do not perform many optimizations. This can be used to speed up startup time.
-  - `-Djava.security.egd=file:/dev/./urandom ` - This can be used to speed up random number generation.
-- `slimJar` - Whether to generate a small JAR with external dependencies, or rather to generate a fat jar with embedded dependencies.
-- `useEmbeddedPaths` - Whehter to use classpath and mainclass embedded in JAR or if they should be supplied on the command line.
+
+Please see https://github.com/ev3dev-lang-java/gradle-plugin#all-configuration-options for a list of options.
 
 ## Gradle Tasks
 
-The project has some tasks developed to interact in 3 areas:
-
-- EV3Dev-lang-java
-- EV3Dev
-- Installer
-
-
-You can use the Java IDE to launch the tasks or you can execute them from the terminal:
-```bash
-./gradlew deployRun
-```
-
-### EV3Dev-lang-java tasks
-- `testConnection` - Test connection to the brick.
-- `deploy` - Deploy a new build of the program to the brick.
-- `deployRun` - Deploy a new build of the program to the brick and then run it.
-- `run` - Run the program that is currently loaded on the brick.
-- `undeploy` - Remove previously uploaded JAR.
-- `pkillJava` - Kill running Java instances.
-- `fatJar` - Build a fat JAR with all dependencies included inside.
-
-### Installer tasks
-- `helpInstall` - Print the installer help.
-- `getInstaller` - Download the installer to the brick.
-- `installJava` - Install Java on the brick.
-- `installOpenCV` - Install OpenCV libraries on the brick.
-- `installRXTX` - Install RXTX library on the brick.
-- `installJavaLibraries` - Install EV3Dev-lang-java libraries on the brick.
-- `javaVersion` - Print Java version which is present on the brick.
-- `updateAPT` - Update APT package cache.
-
-### EV3Dev tasks
-- `ev3devInfo` - Get system summary from `ev3dev-sysinfo -m`.
-- `free` - Print free memory summary.
-- `getDebianDistro` - Get Debian version information from `/etc/os-release`.
-- `ps` - Print list of running processes.
-- `stopBluetooth`/`restartBluetooth` - Stop/restart the Bluetooth service.
-- `stopBrickman`/`restartBrickman` - Stop/restart the Brickman service.
-- `stopNmbd`/`restartNmbd` - Stop/restart the NMBD service.
-- `stopNtp`/`restartNtp` - Stop/restart the NTP service.
-- `shutdown` - Shut down the brick.
+Please see https://github.com/ev3dev-lang-java/gradle-plugin#all-provided-gradle-tasks .
 
 ## Javadocs
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'idea'
     id "net.ossindex.audit" version "0.4.5-beta"
     id "com.github.johnrengelman.shadow" version "4.0.3"
-    id 'com.github.ev3dev-lang-java.gradle-plugin' version '1.6.11'
+    id 'com.github.ev3dev-lang-java.gradle-plugin' version '2.0.0'
 }
 
 version = '2.6.0'


### PR DESCRIPTION
This PR updates the Gradle plugin version and replaces outdated documentation with the one provided by the Gradle plugin documentation (which has in turn evolved from the template-project's documentation).